### PR TITLE
Remove Project Definition Description from README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Native Apps Templates
+**Note**: Snowflake CLI is in Private Preview (PrPr). For more information, you can contact a Snowflake sales representative.
+
 This repository contains templates released by Snowflake Inc for [Native App Framework](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about).
 
 ## Available Templates
@@ -18,8 +20,10 @@ These templates are not an exhaustive list of use cases or possibilities that de
 There are two ways you can use the templates provided in this repository. 
 
 1. Using SnowCLI (recommended)
+
+    Please refer to the online Snowflake Documentation on installing and using SnowCLI to create Native Applications for more information. 
     
-    Run the following command in your terminal.
+    Assuming you have everything set up, run the following command in your terminal.
     ```
     snow app init <project_name> [--template={basic|streamlit-python|streamlit-java}]
     ```
@@ -27,8 +31,6 @@ There are two ways you can use the templates provided in this repository.
     ```
     snow app init <project_name> [--template-repo=https://github.com/snowflakedb/native-apps-templates.git] [--template={basic|streamlit-python|streamlit-java}]
     ```
-
-    For more information on using `snow app`, or SnowCLI in general, refer to [SnowCli](https://github.com/Snowflake-Labs/snowcli/). 
 
 2. Using git clone
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ There are two ways you can use the templates provided in this repository.
 
 1. Using SnowCLI (recommended)
 
-    Please refer to the online Snowflake Documentation on installing and using SnowCLI to create Native Applications for more information. 
+    For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
     
-    Assuming you have everything set up, run the following command in your terminal.
+    Once SnowCLI is installed and configured, run the following command in your terminal.
     ```
     snow app init <project_name> [--template={basic|streamlit-python|streamlit-java}]
     ```

--- a/basic/README.md
+++ b/basic/README.md
@@ -14,18 +14,4 @@ This is the basic project template for a Snowflake Native Apps project. It conta
 ### Adding a snowflake.local.yml file
 Though your project directory already comes with a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-Create a `snowflake.local.yml` file with relevant values to the fields, defaults are described below.
-```
-native_app:
-  package:
-    role: <your_app_pkg_owner_role, resolved connection* role by default>
-    name: <name_of_app_pkg, project_name_pkg_$USER by default>
-
-  application:
-    role: <your_app_owner_role, accountadmin by default>
-    name: <name_of_app, project_name_$USER by default>
-    debug: <true|false, true by default>
-    warehouse: <your_app_warehouse, resolved connection* warehouse by default>
-
-```
-resolved connection* - If snowCLI was installed correctly, there should be a global [config.toml](https://docs.snowflake.com/LIMITEDACCESS/snowcli/connecting/connect#how-to-add-snowflake-credentials-using-a-configuration-file) file where you specify a connection, and a user for that connection. The connection role is derived from this user, or via a role override within the config.toml file. Similarly, a connection warehouse is also derived from a warehouse specified as part of a connection.
+Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 

--- a/basic/README.md
+++ b/basic/README.md
@@ -14,4 +14,4 @@ This is the basic project template for a Snowflake Native Apps project. It conta
 ### Adding a snowflake.local.yml file
 Though your project directory already comes with a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
+For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 

--- a/streamlit-java/README.md
+++ b/streamlit-java/README.md
@@ -2,7 +2,6 @@
 
 This is an example template for a Snowflake Native Apps project which demonstrates the use of Java extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
 
-You cannot use this template as-is to create an application package and install an application. Please read below to understand the required intermediate steps.
 
 # How to build/test this template
 ## Build the jar
@@ -21,7 +20,7 @@ Create or update an Application Package in your Snowflake account, upload applic
 snow app run
 ```
 
-Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
+For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications.  
 
 # Directory Structure
 ## `/app`
@@ -62,9 +61,9 @@ This directory contains code organization by functionality, such as one distinct
 ## `snowflake.yml.jinja`
 While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. Below are some of the configuration keys that you can use in `snowflake.yml` file. 
 
-Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
+For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
 
 ## Adding a snowflake.local.yml file
 Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
+For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 

--- a/streamlit-java/README.md
+++ b/streamlit-java/README.md
@@ -2,6 +2,8 @@
 
 This is an example template for a Snowflake Native Apps project which demonstrates the use of Java extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
 
+You cannot use this template as-is to create an application package and install an application. Please read below to understand the required intermediate steps.
+
 # How to build/test this template
 ## Build the jar
 You need to build the Java application (module-add) to get the .jar file, assuming JDK and Maven are installed and properly configured. 
@@ -18,6 +20,8 @@ Create or update an Application Package in your Snowflake account, upload applic
 ```
 snow app run
 ```
+
+Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
 
 # Directory Structure
 ## `/app`
@@ -56,105 +60,11 @@ This directory contains code organization by functionality, such as one distinct
 ```
 
 ## `snowflake.yml.jinja`
-While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. Below are some of the configuration keys that you can use in `snowflake.yml` file.
+While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. Below are some of the configuration keys that you can use in `snowflake.yml` file. 
 
-### `native_app.name`
-**Required: Yes**<br/>
-**Example value: `myapp`**<br/>
-**Default: `<native_app_project_directory_name>`**<br/>
-An identifier you can refer to this project by. Allows SnowCLI to detect if an associated application package (derived from this name) exists in connected accounts and prevents tooling from interacting with unrelated (but identically named) objects in an account, by tagging the application / application package as belonging to this project. The file called `snowflake.yml.jinja` will be rendered as `snowflake.yml` file with the name of your Native App project as the default value to this field. 
-
-### `native_app.deploy_root`
-**Required: No**<br/>
-**Default: `output/deploy/`**<br/>
-This will be a folder where all artifacts from your build step will be copied to. These artifacts are ready to be deployed to a Snowflake stage, described below. 
-
-### `native_app.source_stage`
-**Required: No**<br/>
-**Default: `app_src.stage`**<br/>
-This is the identifier to a stage that will hold the application artifacts. It is specified as `<schema_name>.<stage_name>` and lives within the Application Package object. It is customizable so that name collisions can be prevented.
-
-### `native_app.package.scripts`
-**Required: No**<br/>
-**Example values:** <br/>
-\- package/schema1.sql<br/>
-\- package/schema2.sql
-
-List of SQL file paths relative to the project root. These files are executed as the provider whenever you deploy your application package, e.g. to populate shared content. As such, they must be idempotent.
-
-
-### `native_app.artifacts`
-**Required: Yes**<br/>
-**Example values:**<br/>
-```
-- src: app/*
-  dest: ./
-- src: streamlit/*
-  dest: streamlit/
-- src: src/resources/images/snowflake.png
-  dest: streamlit/
-```
-
-List of source / destination pairs for files to be added to the deploy root.
-
-If src refers to just one file (not a glob), dest can refer to a target path or a path + name (to support renaming).
-
-Destination paths must end with “/”; if a glob pattern’s destination does not end with a “/”, this will be treated as an error. If omitted, “dest” defaults to the same string as “src”.
-
-Short-form: can also pass in a string for each list item instead of a dict; in this case, the value is treated as both “src” and “dest”.
-
-
-### `native_app.package.role`
-**Required: No**<br/>
-**Default: _Resolved connection role_**<br/>
-The role used to create the application package / provider-side objects. If empty, the role specified on the SnowCLI connection will be used.
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.package.name`
-**Required: No**<br/>
-**Default: _{native_app.name}\_pkg\_$USER_**<br/>
-The name used to create / reference the application package that will be created when you run “snow app run”.
-`$USER` can be ordinary `$USER`, `$USERNAME` or `$LOGNAME` environment variables, depending on your platform. 
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.role`
-**Required: No**<br/>
-**Default: _Resolved connection role_**<br/>
-The role used to create the application instance / consumer-side objects. If empty, the role specified on the SnowCLI connection will be used.
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.name`
-**Required: No**<br/>
-**Default: _{native_app.name}\_$USER_**<br/>
-The name used to create / reference the (loose files) application that will be created when you run “snow app run“.
-`$USER` can be ordinary `$USER`, `$USERNAME` or `$LOGNAME` environment variables, depending on your platform. 
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.warehouse`
-**Required: No**<br/>
-**Default: _Resolved connection warehouse_**<br/>
-The warehouse used to install the application. If empty, the warehouse specified on the SnowCLI connection will be used. If no warehouse is specified there, it is not a validation error, but the application will fail to install.
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.debug`
-**Required: No**<br/>
-**Default: True**<br/>
-Whether the debug mode is enabled, when the application is installed using the loose files mode.
+Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
 
 ## Adding a snowflake.local.yml file
 Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-Create a `snowflake.local.yml` file with relevant values to the fields, defaults are described in the preceding section.
-```
-native_app:
-  package:
-    role: <your_app_pkg_owner_role>
-    name: <name_of_app_pkg>
-
-  application:
-    role: <your_app_owner_role>
-    name: <name_of_app>
-    debug: <true|false>
-    warehouse: <your_app_warehouse>
-
-```
+Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 

--- a/streamlit-python/README.md
+++ b/streamlit-python/README.md
@@ -12,7 +12,7 @@ Create or update an Application Package in your Snowflake account, upload applic
 snow app run
 ```
 
-Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
+For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
 
 # Directory Structure
 ## `/app`
@@ -54,9 +54,9 @@ This directory contains code organization by functionality, such as one distinct
 ## `snowflake.yml.jinja`
 While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. Below are some of the configuration keys that you can use in `snowflake.yml` file.
 
-Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
+For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
 
 ## Adding a snowflake.local.yml file
 Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
+For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 

--- a/streamlit-python/README.md
+++ b/streamlit-python/README.md
@@ -2,7 +2,7 @@
 
 This is an example template for a Snowflake Native Apps project which demonstrates the use of Python extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
 
-Since this template contains python files only, you do not need to build the source code with any additional step. You can directly go to the next section. However, if there were any source code that needed to be built, you would manully perform the build steps here before proceeding to the next section. 
+Since this template contains python files only, you do not need to build the source code with any additional step. You can directly go to the next section. However, if there were any source code that needed to be built, you would manually perform the build steps here before proceeding to the next section. 
 
 Similarly, you can also use your own build steps for any other languages supported by Snowflake that you wish to write your code in. For more information on supported languages, visit [docs](https://docs.snowflake.com/en/developer-guide/stored-procedures-vs-udfs#label-sp-udf-languages).
 
@@ -11,6 +11,8 @@ Create or update an Application Package in your Snowflake account, upload applic
 ```
 snow app run
 ```
+
+Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
 
 # Directory Structure
 ## `/app`
@@ -52,103 +54,9 @@ This directory contains code organization by functionality, such as one distinct
 ## `snowflake.yml.jinja`
 While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. Below are some of the configuration keys that you can use in `snowflake.yml` file.
 
-### `native_app.name`
-**Required: Yes**<br/>
-**Example value: `myapp`**<br/>
-**Default: `<native_app_project_directory_name>`**<br/>
-An identifier you can refer to this project by. Allows SnowCLI to detect if an associated application package (derived from this name) exists in connected accounts and prevents tooling from interacting with unrelated (but identically named) objects in an account, by tagging the application / application package as belonging to this project. The file called `snowflake.yml.jinja` will be rendered as `snowflake.yml` file with the name of your Native App project as the default value to this field. 
-
-### `native_app.deploy_root`
-**Required: No**<br/>
-**Default: `output/deploy/`**<br/>
-This will be a folder where all artifacts from your build step will be copied to. These artifacts are ready to be deployed to a Snowflake stage, described below. 
-
-### `native_app.source_stage`
-**Required: No**<br/>
-**Default: `app_src.stage`**<br/>
-This is the identifier to a stage that will hold the application artifacts. It is specified as `<schema_name>.<stage_name>` and lives within the Application Package object. It is customizable so that name collisions can be prevented.
-
-### `native_app.package.scripts`
-**Required: No**<br/>
-**Example values:** <br/>
-\- package/schema1.sql<br/>
-\- package/schema2.sql
-
-List of SQL file paths relative to the project root. These files are executed as the provider whenever you deploy your application package, e.g. to populate shared content. As such, they must be idempotent.
-
-
-### `native_app.artifacts`
-**Required: Yes**<br/>
-**Example values:**<br/>
-```
-- src: app/*
-  dest: ./
-- src: streamlit/*
-  dest: streamlit/
-- src: src/resources/images/snowflake.png
-  dest: streamlit/
-```
-
-List of source / destination pairs for files to be added to the deploy root.
-
-If src refers to just one file (not a glob), dest can refer to a target path or a path + name (to support renaming).
-
-Destination paths must end with “/”; if a glob pattern’s destination does not end with a “/”, this will be treated as an error. If omitted, “dest” defaults to the same string as “src”.
-
-Short-form: can also pass in a string for each list item instead of a dict; in this case, the value is treated as both “src” and “dest”.
-
-
-### `native_app.package.role`
-**Required: No**<br/>
-**Default: _Resolved connection role_**<br/>
-The role used to create the application package / provider-side objects. If empty, the role specified on the SnowCLI connection will be used.
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.package.name`
-**Required: No**<br/>
-**Default: _{native_app.name}\_pkg\_$USER_**<br/>
-The name used to create / reference the application package that will be created when you run “snow app run”.
-`$USER` can be ordinary `$USER`, `$USERNAME` or `$LOGNAME` environment variables, depending on your platform. 
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.role`
-**Required: No**<br/>
-**Default: _Resolved connection role_**<br/>
-The role used to create the application instance / consumer-side objects. If empty, the role specified on the SnowCLI connection will be used.
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.name`
-**Required: No**<br/>
-**Default: _{native_app.name}\_$USER_**<br/>
-The name used to create / reference the (loose files) application that will be created when you run “snow app run“.
-`$USER` can be ordinary `$USER`, `$USERNAME` or `$LOGNAME` environment variables, depending on your platform. 
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.warehouse`
-**Required: No**<br/>
-**Default: _Resolved connection warehouse_**<br/>
-The warehouse used to install the application. If empty, the warehouse specified on the SnowCLI connection will be used. If no warehouse is specified there, it is not a validation error, but the application will fail to install.
-_Note: typically specified in snowflake.local.yml, described in the last section._
-
-### `native_app.application.debug`
-**Required: No**<br/>
-**Default: True**<br/>
-Whether the debug mode is enabled, when the application is installed using the loose files mode.
+Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 
 
 ## Adding a snowflake.local.yml file
 Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-Create a `snowflake.local.yml` file with relevant values to the fields, defaults are described in the preceding section.
-```
-native_app:
-  package:
-    role: <your_app_pkg_owner_role>
-    name: <name_of_app_pkg>
-
-  application:
-    role: <your_app_owner_role>
-    name: <name_of_app>
-    debug: <true|false>
-    warehouse: <your_app_warehouse>
-
-```
+Please refer to the online Snowflake Documentation on using SnowCLI to create Native Applications for more information on this. 


### PR DESCRIPTION
This PR removes description of project definition files, among other small edits, from the readme files of the templates. This is to remove any disparity that will inevitably occur between the documentation as source of truth and what is described in these README files. 