### PR TITLE
PMM Updates to Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # v1.0.0
 
 ## New additions
-* Three different templates that allow you to explore using Snowflake CLI with a Snowflake Native App. These are basic, streamlit-java and streamlit-python.
+* Three different templates that allow you to explore using Snowflake CLI with a Snowflake Native App. These templates are named basic, streamlit-java and streamlit-python.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # v1.0.0
 
 ## New additions
-* Three different templates that allow you to explore different offerings of Snowflake Native Apps. These are basic, streamlit-java and streamlit-python.
+* Three different templates that allow you to explore using Snowflake CLI with a Snowflake Native App. These are basic, streamlit-java and streamlit-python.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Native Apps Templates
+# Snowflake Native App Templates with Snowflake CLI
 **Note**: Snowflake CLI is in Private Preview (PrPr). For more information, you can contact a Snowflake sales representative.
 
 This repository contains [Snowflake Native App](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about) templates released by Snowflake Inc. These templates are customized to work with Snowflake CLI. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Native Apps Templates
 **Note**: Snowflake CLI is in Private Preview (PrPr). For more information, you can contact a Snowflake sales representative.
 
-This repository contains templates released by Snowflake Inc for [Native App Framework](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about).
+This repository contains [Snowflake Native App](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about) templates released by Snowflake Inc. These templates are customized to work with Snowflake CLI. 
 
 ## Available Templates
 There are three available templates in the current version of this repository:
@@ -9,21 +9,21 @@ There are three available templates in the current version of this repository:
 2. [streamlit-python](./streamlit-python/README.md)
 3. [streamlit-java](./streamlit-java/README.md)
 
-For a detailed understanding of the templates, please refer to the README.md that comes with each of the templates. 
+For a detailed understanding of the templates, please refer to the README.md within each template. 
 
 ### Note
-These templates are not an exhaustive list of use cases or possibilities that developers may want to explore when building Native Apps. 
+These templates are not an exhaustive list of use cases or possibilities that developers may want to explore when building their Snowflake Native App. 
 
 
 ## How to Use the Templates
 
 There are two ways you can use the templates provided in this repository. 
 
-1. Using SnowCLI (recommended)
+1. Using Snowflake CLI (recommended)
 
-    For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
+    For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
     
-    Once SnowCLI is installed and configured, run the following command in your terminal.
+    Once Snowflake CLI is installed and configured, run the following command in your terminal.
     ```
     snow app init <project_name> [--template={basic|streamlit-python|streamlit-java}]
     ```
@@ -34,4 +34,4 @@ There are two ways you can use the templates provided in this repository.
 
 2. Using git clone
 
-    You can also clone this repository manually and keep the template you would like to use. But as a note, any jinja files in this repository will not be rendered to their intended file type if using a simple git clone/no snowCLI. 
+    You can also clone this repository manually and keep the template you would like to use. But as a note, any jinja files in this repository will not be rendered to their intended file type if using this option. 

--- a/basic/README.md
+++ b/basic/README.md
@@ -1,17 +1,17 @@
 ## Introduction
 
-This is the basic project template for a Snowflake Native Apps project. It contains minimal code meant to help you set up your first application instance in your account quickly.
+This is the basic project template for a Snowflake Native App project. It contains minimal code meant to help you set up your first application object in your account quickly.
 
 ### Project Structure
 | File Name | Purpose |
 | --------- | ------- |
-| README.md | The current file you are looking at, meant to guide you through a native apps project. |
-| app/setup_script.sql | Contains SQL statements that are run when an account installs or upgrades an application. |
+| README.md | The current file you are looking at, meant to guide you through a Snowflake Native App project. |
+| app/setup_script.sql | Contains SQL statements that are run when an account installs or upgrades a Snowflake Native App. |
 | app/manifest.yml | Defines properties required by the application package. Find more details at the [Manifest Documentation.](https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest)
-| app/README.md | Exposed to the account installing the application with details on purpose and how to use the application. |
-| snowflake.yml | Used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. |
+| app/README.md | Exposed to the account installing the Snowflake Native App with details on what it does and how to use it. |
+| snowflake.yml | Used by the Snowflake CLI tool to discover your project's code and interact with your Snowflake account with all relevant permissions and grants. |
 
 ### Adding a snowflake.local.yml file
-Though your project directory already comes with a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
+Though your project directory already comes with a `snowflake.yml` file, an individual developer can choose to customize the behavior of the Snowflake CLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 

--- a/basic/README.md
+++ b/basic/README.md
@@ -9,7 +9,7 @@ This is the basic project template for a Snowflake Native App project. It contai
 | app/setup_script.sql | Contains SQL statements that are run when an account installs or upgrades a Snowflake Native App. |
 | app/manifest.yml | Defines properties required by the application package. Find more details at the [Manifest Documentation.](https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest)
 | app/README.md | Exposed to the account installing the Snowflake Native App with details on what it does and how to use it. |
-| snowflake.yml | Used by the Snowflake CLI tool to discover your project's code and interact with your Snowflake account with all relevant permissions and grants. |
+| snowflake.yml | Used by the Snowflake CLI tool to discover your project's code and interact with your Snowflake account with all relevant prvileges and grants. |
 
 ### Adding a snowflake.local.yml file
 Though your project directory already comes with a `snowflake.yml` file, an individual developer can choose to customize the behavior of the Snowflake CLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.

--- a/basic/app/README.md
+++ b/basic/app/README.md
@@ -1,8 +1,8 @@
-## Welcome to your First Native Application!
+## Welcome to your First Snowflake Native App!
 
-In this application, you will be able to explore some basic concepts such as application role, versioned schemas and creating procedures and functions within a setup script.
+In this Snowflake Native App, you will be able to explore some basic concepts such as application role, versioned schemas and creating procedures and functions within a setup script.
 
-For a deep dive into the world of Native Apps, please read the [official Snowflake documentation](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about) which goes in depth about many additional functionalities of this framework.
+For more information about a Snowflake Native App, please read the [official Snowflake documentation](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about) which goes in depth about many additional functionalities of this framework.
 
 ## Using the application after installation
 To interact with the application after it has successfully installed in your account, switch to the application owner role first.

--- a/basic/app/manifest.yml
+++ b/basic/app/manifest.yml
@@ -1,4 +1,4 @@
-# This is a manifest.yml file, a required component of creating a native application. 
+# This is a manifest.yml file, a required component of creating a Snowflake Native App. 
 # This file defines properties required by the application package, including the location of the setup script and version definitions.
 # Refer to https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest for a detailed understanding of this file. 
 

--- a/basic/app/setup_script.sql
+++ b/basic/app/setup_script.sql
@@ -1,4 +1,4 @@
--- This is the setup script that will run while installing a Snowflake Native App in a consumer's account.
+-- This is the setup script that runs while installing a Snowflake Native App in a consumer account.
 -- To write this script, you can familiarize yourself with some of the following concepts:
 -- Application Roles
 -- Versioned Schemas

--- a/basic/app/setup_script.sql
+++ b/basic/app/setup_script.sql
@@ -1,4 +1,4 @@
--- This is the setup script that will run while installing your application instance in a consumer's account.
+-- This is the setup script that will run while installing a Snowflake Native App in a consumer's account.
 -- To write this script, you can familiarize yourself with some of the following concepts:
 -- Application Roles
 -- Versioned Schemas

--- a/basic/snowflake.yml.jinja
+++ b/basic/snowflake.yml.jinja
@@ -1,5 +1,4 @@
-# This is a project definition file, a required component of the Snowflake Native Apps Project.
-# DO NOT delete this file if you intend to use snowCLI with this project.  
+# This is a project definition file, a required component if you intend to use Snowflake CLI in a project directory such as this template.
 
 definition_version: 1
 native_app:

--- a/streamlit-java/README.md
+++ b/streamlit-java/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This is an example template for a Snowflake Native Apps project which demonstrates the use of Java extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
+This is an example template for a Snowflake Native App project which demonstrates the use of Java extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
 
 
 # How to build/test this template
@@ -15,28 +15,28 @@ mvn package
 Similarly, you can also use your own build steps for any other languages supported by Snowflake that you wish to write your code in, and any build automation tools you prefer. For more information on supported languages, visit [docs](https://docs.snowflake.com/en/developer-guide/stored-procedures-vs-udfs#label-sp-udf-languages).
 
 ## Run the app
-Create or update an Application Package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an Application instance based on the uploaded artifacts.
+Create or update an application package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an application object ub the same account based on the uploaded artifacts.
 ```
 snow app run
 ```
 
-For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications.  
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App.  
 
 # Directory Structure
 ## `/app`
 This directory holds your Snowflake Native App files.
 
 ### `/app/README.md`
-Exposed to the account installing the application with details on purpose and how to use the application.
+Exposed to the account installing the Snowflake Native App with details on what it does and how to use it.
 
 ### `/app/manifest.yml`
 Defines properties required by the application package. Find more details at the [Manifest Documentation.](https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest)
 
 ### `/app/setup_script.sql`
-Contains SQL statements that are run when an account installs or upgrades an application.
+Contains SQL statements that are run when an account installs or upgrades a Snowflake Native App.
 
 ## `/scripts`
-You can add any additional scripts such as `.sql` and `.jinja` files here. One of the common use cases for such a script is to be able to add shared content from external databases to your application package, which makes it available to be used in the setup script that runs during application installation. 
+You can add any additional scripts such as `.sql` and `.jinja` files here. One of the common use cases for such a script is to be able to add shared content from external databases to your application package, which makes it available to be used in the setup script that runs during Snowflake Native App installation. 
 _Note: As of now, `snow app init` does not render these jinja templates for you into the required files, if you decide to use them. You will have to manually render them for now._
 
 
@@ -59,11 +59,11 @@ This directory contains code organization by functionality, such as one distinct
 ```
 
 ## `snowflake.yml.jinja`
-While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. Below are some of the configuration keys that you can use in `snowflake.yml` file. 
+While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant permissions and grants.
 
-For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 
 
 ## Adding a snowflake.local.yml file
-Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
+Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of Snowflake CLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 

--- a/streamlit-java/README.md
+++ b/streamlit-java/README.md
@@ -15,7 +15,7 @@ mvn package
 Similarly, you can also use your own build steps for any other languages supported by Snowflake that you wish to write your code in, and any build automation tools you prefer. For more information on supported languages, visit [docs](https://docs.snowflake.com/en/developer-guide/stored-procedures-vs-udfs#label-sp-udf-languages).
 
 ## Run the app
-Create or update an application package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an application object ub the same account based on the uploaded artifacts.
+Create or update an application package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an application object in the same account based on the uploaded artifacts.
 ```
 snow app run
 ```
@@ -61,9 +61,9 @@ This directory contains code organization by functionality, such as one distinct
 ## `snowflake.yml.jinja`
 While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant permissions and grants.
 
-For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
 
 ## Adding a snowflake.local.yml file
 Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of Snowflake CLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 

--- a/streamlit-java/README.md
+++ b/streamlit-java/README.md
@@ -59,7 +59,7 @@ This directory contains code organization by functionality, such as one distinct
 ```
 
 ## `snowflake.yml.jinja`
-While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant prvileges and grants.
+While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant privileges and grants.
 
 For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
 

--- a/streamlit-java/README.md
+++ b/streamlit-java/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This is an example template for a Snowflake Native App project which demonstrates the use of Java extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
+This is an example template for a Snowflake Native App project which demonstrates the use of Java extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis of functionality, as well as to indicate the contents of some common and useful files. 
 
 
 # How to build/test this template
@@ -59,7 +59,7 @@ This directory contains code organization by functionality, such as one distinct
 ```
 
 ## `snowflake.yml.jinja`
-While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant permissions and grants.
+While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant prvileges and grants.
 
 For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
 

--- a/streamlit-java/app/README.md
+++ b/streamlit-java/app/README.md
@@ -1,3 +1,3 @@
-# Snowflake Native Application - Add
+# Snowflake Native App - Add
 
-This is a sample app that add two numbers using Streamlit and Java.
+This is a sample Snowflake Native App that add two numbers using Streamlit and Java.

--- a/streamlit-java/app/README.md
+++ b/streamlit-java/app/README.md
@@ -1,3 +1,3 @@
 # Snowflake Native App - Add
 
-This is a sample Snowflake Native App that add two numbers using Streamlit and Java.
+This is a sample Snowflake Native App that adds two numbers using Streamlit and Java.

--- a/streamlit-java/app/setup_script.sql
+++ b/streamlit-java/app/setup_script.sql
@@ -1,4 +1,4 @@
--- This is the setup script that will run while installing a Snowflake Native App in a consumer's account.
+-- This is the setup script that runs while installing a Snowflake Native App in a consumer account.
 -- For more information on how to create setup file, visit https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script
 
 -- A general guideline to building this script looks like:

--- a/streamlit-java/app/setup_script.sql
+++ b/streamlit-java/app/setup_script.sql
@@ -1,4 +1,4 @@
--- This is the setup script that will run while installing your application instance in a consumer's account.
+-- This is the setup script that will run while installing a Snowflake Native App in a consumer's account.
 -- For more information on how to create setup file, visit https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script
 
 -- A general guideline to building this script looks like:

--- a/streamlit-java/scripts/any-provider-setup.sql
+++ b/streamlit-java/scripts/any-provider-setup.sql
@@ -1,2 +1,2 @@
--- Any script that should be run as the provider, such as creating and populating database objects that need to be shared with the app pkg. 
+-- Any script that should be run as the provider, such as creating and populating database objects that need to be shared with the application package. 
 -- This script must be idempotent.

--- a/streamlit-java/scripts/any-provider-setup.sql
+++ b/streamlit-java/scripts/any-provider-setup.sql
@@ -1,2 +1,2 @@
--- Any script that should be run as the provider, such as creating and populating database objects that need to be shared with the application package. 
+-- Any script that should be run by the provider, such as creating and populating database objects that need to be shared with the application package. 
 -- This script must be idempotent.

--- a/streamlit-java/snowflake.yml.jinja
+++ b/streamlit-java/snowflake.yml.jinja
@@ -1,5 +1,5 @@
-# This is a project definition file, a required component of the Snowflake Native Apps Project.
-# DO NOT delete this file if you intend to use snowCLI with this project.  
+# This is a project definition file, a required component if you intend to use Snowflake CLI in a project directory such as this template.
+ 
 
 definition_version: 1
 native_app:

--- a/streamlit-python/README.md
+++ b/streamlit-python/README.md
@@ -2,12 +2,12 @@
 
 This is an example template for a Snowflake Native App project which demonstrates the use of Python extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
 
-Since this template contains python files only, you do not need to build the source code with any additional step. You can directly go to the next section. However, if there were any source code that needed to be built, you nned to manually perform the build steps here before proceeding to the next section. 
+Since this template contains python files only, you do not need to build the source code with any additional step. You can directly go to the next section. However, if there were any source code that needed to be built, you need to manually perform the build steps here before proceeding to the next section. 
 
 Similarly, you can also use your own build steps for any other languages supported by Snowflake that you wish to write your code in. For more information on supported languages, visit [docs](https://docs.snowflake.com/en/developer-guide/stored-procedures-vs-udfs#label-sp-udf-languages).
 
 ## Run the app
-Create or update an application package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an application object ub the same account based on the uploaded artifacts.
+Create or update an application package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an application object in the same account based on the uploaded artifacts.
 ```
 snow app run
 ```
@@ -55,12 +55,12 @@ This directory contains code organization by functionality, such as one distinct
 ## `snowflake.yml.jinja`
 While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant permissions and grants. 
 
-For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
 
 ## Adding a snowflake.local.yml file
 Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of Snowflake CLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
 
 ## Unit tests
 To set up and run unit tests, please follow the steps below.

--- a/streamlit-python/README.md
+++ b/streamlit-python/README.md
@@ -1,34 +1,33 @@
 ## Introduction
 
-This is an example template for a Snowflake Native Apps project which demonstrates the use of Python extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
+This is an example template for a Snowflake Native App project which demonstrates the use of Python extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
 
-Since this template contains python files only, you do not need to build the source code with any additional step. You can directly go to the next section. However, if there were any source code that needed to be built, you would manually perform the build steps here before proceeding to the next section. 
+Since this template contains python files only, you do not need to build the source code with any additional step. You can directly go to the next section. However, if there were any source code that needed to be built, you nned to manually perform the build steps here before proceeding to the next section. 
 
 Similarly, you can also use your own build steps for any other languages supported by Snowflake that you wish to write your code in. For more information on supported languages, visit [docs](https://docs.snowflake.com/en/developer-guide/stored-procedures-vs-udfs#label-sp-udf-languages).
 
 ## Run the app
-Create or update an Application Package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an Application instance based on the uploaded artifacts.
+Create or update an application package in your Snowflake account, upload application artifacts to a stage in the application package, and create or update an application object ub the same account based on the uploaded artifacts.
 ```
 snow app run
 ```
 
-For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
-
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App.  
 # Directory Structure
 ## `/app`
 This directory holds your Snowflake Native App files.
 
 ### `/app/README.md`
-Exposed to the account installing the application with details on purpose and how to use the application.
+Exposed to the account installing the application with details on what it does and how to use it.
 
 ### `/app/manifest.yml`
 Defines properties required by the application package. Find more details at the [Manifest Documentation.](https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest)
 
 ### `/app/setup_script.sql`
-Contains SQL statements that are run when an account installs or upgrades an application.
+Contains SQL statements that are run when an account installs or upgrades a Snowflake Native App.
 
 ## `/scripts`
-You can add any additional scripts such as `.sql` and `.jinja` files here. One of the common use cases for such a script is to be able to add shared content from external databases to your application package, which makes it available to be used in the setup script that runs during application installation. 
+You can add any additional scripts such as `.sql` and `.jinja` files here. One of the common use cases for such a script is to be able to add shared content from external databases to your application package, which makes it available to be used in the setup script that runs during Snowflake Native App installation. 
 _Note: As of now, `snow app init` does not render these jinja templates for you into the required files, if you decide to use them. You will have to manually render them for now._
 
 
@@ -54,14 +53,14 @@ This directory contains code organization by functionality, such as one distinct
 ```
 
 ## `snowflake.yml.jinja`
-While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by the snowCLI tool to discover your project's code and interact with snowflake with all relevant permissions and grants. Below are some of the configuration keys that you can use in `snowflake.yml` file.
+While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant permissions and grants. 
 
-For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 
 
 ## Adding a snowflake.local.yml file
-Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of the snowCLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
+Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of Snowflake CLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
 
-For more information, please refer to the Snowflake Documentation on installing and using SnowCLI to create Native Applications. 
+For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Native App. 
 
 ## Unit tests
 To set up and run unit tests, please follow the steps below.

--- a/streamlit-python/README.md
+++ b/streamlit-python/README.md
@@ -1,8 +1,8 @@
 ## Introduction
 
-This is an example template for a Snowflake Native App project which demonstrates the use of Python extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis on functionality, as well as indicate the contents of some common and useful files. 
+This is an example template for a Snowflake Native App project which demonstrates the use of Python extension code and adding Streamlit code. This template is meant to guide developers towards a possible project structure on the basis of functionality, as well as to indicate the contents of some common and useful files. 
 
-Since this template contains python files only, you do not need to build the source code with any additional step. You can directly go to the next section. However, if there were any source code that needed to be built, you need to manually perform the build steps here before proceeding to the next section. 
+Since this template contains Python files only, you do not need to perform any additional steps to build the source code. You can directly go to the next section. However, if there were any source code that needed to be built, you must manually perform the build steps here before proceeding to the next section. 
 
 Similarly, you can also use your own build steps for any other languages supported by Snowflake that you wish to write your code in. For more information on supported languages, visit [docs](https://docs.snowflake.com/en/developer-guide/stored-procedures-vs-udfs#label-sp-udf-languages).
 
@@ -24,10 +24,10 @@ Exposed to the account installing the application with details on what it does a
 Defines properties required by the application package. Find more details at the [Manifest Documentation.](https://docs.snowflake.com/en/developer-guide/native-apps/creating-manifest)
 
 ### `/app/setup_script.sql`
-Contains SQL statements that are run when an account installs or upgrades a Snowflake Native App.
+Contains SQL statements that are run when a consumer installs or upgrades a Snowflake Native App in their account.
 
 ## `/scripts`
-You can add any additional scripts such as `.sql` and `.jinja` files here. One of the common use cases for such a script is to be able to add shared content from external databases to your application package, which makes it available to be used in the setup script that runs during Snowflake Native App installation. 
+You can add any additional scripts such as `.sql` and `.jinja` files here. One common use case for such a script is to add shared content from external databases to your application package. This allows you to refer to the external database in the setup script that runs when a Snowflake Native App is installed.
 _Note: As of now, `snow app init` does not render these jinja templates for you into the required files, if you decide to use them. You will have to manually render them for now._
 
 
@@ -53,12 +53,12 @@ This directory contains code organization by functionality, such as one distinct
 ```
 
 ## `snowflake.yml.jinja`
-While this file exists as a Jinja template, it is the only file that will be automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). `snowflake.yml` is used by Snowflake CLI to discover your project's code and interact with snowflake with all relevant permissions and grants. 
+While this file exists as a Jinja template, it is the only file that is automatically rendered as a `snowflake.yml` file by the `snow app init` command, as described in the [README.md](../README.md). Snowflake CLI uses the `snowflake.yml` file  to discover your project's code and interact with Snowflake using all relevant privileges and grants. 
 
 For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
 
 ## Adding a snowflake.local.yml file
-Though your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of Snowflake CLI by providing local overrides to `snowflake.yml`, such as a new role to test out your own application package. This is where you can use `snowflake.local.yml`, which is not a version-controlled file.
+Although your project directory must have a `snowflake.yml` file, an individual developer can choose to customize the behavior of Snowflake CLI by providing local overrides to the `snowflake.yml` file, such as a new role to test out your own application package. This is where you can use the `snowflake.local.yml` file, which is not a version-controlled file.
 
 For more information, please refer to the Snowflake Documentation on installing and using Snowflake CLI to create a Snowflake Native App. 
 

--- a/streamlit-python/app/README.md
+++ b/streamlit-python/app/README.md
@@ -1,3 +1,3 @@
 # Snowflake Native App - Add
 
-This is a sample Snowflake Native App that add two numbers using Streamlit and Python.
+This is a sample Snowflake Native App that adds two numbers using Streamlit and Python.

--- a/streamlit-python/app/README.md
+++ b/streamlit-python/app/README.md
@@ -1,3 +1,3 @@
-# Snowflake Native Application - Add
+# Snowflake Native App - Add
 
-This is a sample app that add two numbers using Streamlit and Python.
+This is a sample Snowflake Native App that add two numbers using Streamlit and Python.

--- a/streamlit-python/app/setup_script.sql
+++ b/streamlit-python/app/setup_script.sql
@@ -1,4 +1,4 @@
--- This is the setup script that will run while installing a Snowflake Native App in a consumer's account.
+-- This is the setup script that runs while installing a Snowflake Native App in a consumer account.
 -- For more information on how to create setup file, visit https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script
 
 -- A general guideline to building this script looks like:

--- a/streamlit-python/app/setup_script.sql
+++ b/streamlit-python/app/setup_script.sql
@@ -1,4 +1,4 @@
--- This is the setup script that will run while installing your application instance in a consumer's account.
+-- This is the setup script that will run while installing a Snowflake Native App in a consumer's account.
 -- For more information on how to create setup file, visit https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script
 
 -- A general guideline to building this script looks like:

--- a/streamlit-python/scripts/any-provider-setup.sql
+++ b/streamlit-python/scripts/any-provider-setup.sql
@@ -1,2 +1,2 @@
--- Any script that should be run as the provider, such as creating and populating database objects that need to be shared with the app pkg. 
+-- Any script that should be run as the provider, such as creating and populating database objects that need to be shared with the application package.
 -- This script must be idempotent.

--- a/streamlit-python/snowflake.yml.jinja
+++ b/streamlit-python/snowflake.yml.jinja
@@ -1,5 +1,5 @@
-# This is a project definition file, a required component of the Snowflake Native Apps Project.
-# DO NOT delete this file if you intend to use snowCLI with this project.  
+# This is a project definition file, a required component if you intend to use Snowflake CLI in a project directory such as this template.
+
 
 definition_version: 1
 native_app:


### PR DESCRIPTION
The PMM and the Snowflake CLI team have mentioned certain rules to follow when naming objects in the Snowflake Native App world:

1. Snowflake CLI to be used in place of snowCLI.
2. Snowflake Native App for the framework, and the application installed in a consumer account from a listing. This is also being used in a generic context when referring to an application.
3. Application object for the same account installation of an application.
4. Application package for app pkg/application pkg etc.

Adding @sfc-gh-sleslie for his review as well.