### PR TITLE
Pin streamlit to 1.22

### DIFF
--- a/streamlit-java/src/module-ui/src/environment.yml
+++ b/streamlit-java/src/module-ui/src/environment.yml
@@ -2,3 +2,5 @@
 # For more details, refer to https://docs.snowflake.com/en/developer-guide/streamlit/create-streamlit-sql#label-streamlit-install-packages-manual
 channels:
 - snowflake
+dependencies:
+- streamlit=1.22

--- a/streamlit-python/src/module-ui/src/environment.yml
+++ b/streamlit-python/src/module-ui/src/environment.yml
@@ -3,3 +3,5 @@
 
 channels:
 - snowflake
+dependencies:
+- streamlit=1.22


### PR DESCRIPTION
Ensure that templates that utilize Streamlit-in-Snowflake are pinned to the latest stable version available (1.22 at time of writing).

- [x] I have successfully deployed and manually tested apps based on templates changed here