### PR TITLE
Add UDF/SPROCs registration in local testing framework

### DIFF
--- a/streamlit-python/local_test_env.yml
+++ b/streamlit-python/local_test_env.yml
@@ -4,10 +4,10 @@ channels:
   - snowflake
 dependencies:
   - python=3.8
-  - snowflake-snowpark-python>=1.15.0
   - pip
   - pip:
       - pytest
-      - snowflake-cli-labs>=2.0.0
+      - snowflake-cli-labs
+      - snowflake-snowpark-python>=1.15.0
       - streamlit>=1.28.0 # this version could be different than the streamlit version in Snowflake, and therefore, 100% compatibility is not guaranteed.
 

--- a/streamlit-python/local_test_env.yml
+++ b/streamlit-python/local_test_env.yml
@@ -4,9 +4,10 @@ channels:
   - snowflake
 dependencies:
   - python=3.8
-  - snowflake-snowpark-python
+  - snowflake-snowpark-python>=1.15.0
   - pip
   - pip:
       - pytest
+      - snowflake-cli-labs>=2.0.0
       - streamlit>=1.28.0 # this version could be different than the streamlit version in Snowflake, and therefore, 100% compatibility is not guaranteed.
 

--- a/streamlit-python/src/module-ui/src/ui.py
+++ b/streamlit-python/src/module-ui/src/ui.py
@@ -4,8 +4,8 @@ def run_streamlit():
    # Streamlit app testing documentation: https://docs.streamlit.io/library/api-reference/app-testing
    import pandas as pd
    import streamlit as st
-   from snowflake.snowpark.context import get_active_session
    from snowflake.snowpark.functions import call_udf, col
+   from snowflake.snowpark import Session
 
    st.title('Hello Snowflake!')
 
@@ -18,7 +18,7 @@ def run_streamlit():
       """)
 
    # Get the current credentials
-   session = get_active_session()
+   session = Session.builder.getOrCreate()
 
    num1 = st.number_input('First number', key='numToAdd1', value=1)
    num2 = st.number_input('Second number', key='numToAdd2', value=1)

--- a/streamlit-python/src/module-ui/test/test_ui.py
+++ b/streamlit-python/src/module-ui/test/test_ui.py
@@ -1,46 +1,28 @@
-import pytest
+from pytest import fixture
 from snowflake.snowpark import Session
-from snowflake.snowpark.column import ColumnOrLiteral, Column
 from snowflake.snowpark.functions import lit
 from streamlit.testing.v1 import AppTest
-from unittest.mock import patch
-from add import increment_by_one_fn
+import add as add
 import ui as ui
 
-@pytest.fixture()
+@fixture
 def session():
     session = Session.builder.config('local_testing', True).create()
     yield session
     session.close()
 
-test_core_add_result = 9
+@fixture(autouse=True)
+def set_up(session: Session):
+    session.sproc.register(add.increment_by_one_fn, name='core.increment_by_one')
+    session.udf.register(add.add_fn, name='core.add')
 
-def mock_call_udf(udf_name: str, *args: ColumnOrLiteral):
-    if udf_name == 'core.add':
-        return lit(test_core_add_result)
-    else:
-        raise NotImplementedError
-    
-def mock_call_sproc(session: Session, sproc_name: str, *args):
-    if sproc_name == 'core.increment_by_one':
-        return increment_by_one_fn(session, args[0])
-    else:
-        raise NotImplementedError
-
-@patch('snowflake.snowpark.session.Session.call', autospec=True)
-@patch('snowflake.snowpark.functions.call_udf')
-@patch('snowflake.snowpark.context.get_active_session')
-def test_streamlit(get_active_session, call_udf, call_sproc, session: Session):
-    get_active_session.return_value = session
-    call_udf.side_effect = mock_call_udf
-    call_sproc.side_effect = mock_call_sproc
-
+def test_streamlit():
     at = AppTest.from_function(ui.run_streamlit)
     at.run()
 
     at.number_input('numToAdd1').set_value(6).run()
     at.number_input('numToAdd2').set_value(3).run()
-    assert (at.dataframe[0].value[:].values == [[test_core_add_result]]).all()
+    assert (at.dataframe[0].value[:].values == [[9]]).all()
 
     at.number_input('numToIncrement').set_value(4).run()
     assert (at.dataframe[1].value[:].values == [[5]]).all()


### PR DESCRIPTION
- Add UDF/SPROCs registration in local testing framework
- Switch to using  Session.builder.getOrCreate() so it works in multiple environments without changes.