### PR TITLE
Bump Streamlit version to 1.26, fixes #10

### DIFF
--- a/streamlit-java/.gitignore
+++ b/streamlit-java/.gitignore
@@ -1,2 +1,3 @@
 snowflake.local.yml
 output/**
+target

--- a/streamlit-java/src/module-ui/src/environment.yml
+++ b/streamlit-java/src/module-ui/src/environment.yml
@@ -3,4 +3,4 @@
 channels:
 - snowflake
 dependencies:
-- streamlit=1.22.0
+- streamlit=1.26.0

--- a/streamlit-python/local_test_env.yml
+++ b/streamlit-python/local_test_env.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
       - pytest
-      - snowflake-cli-labs
+      - snowflake-cli-labs>=2.0.0
       - snowflake-snowpark-python>=1.15.0
       - streamlit>=1.28.0 # this version could be different than the streamlit version in Snowflake, and therefore, 100% compatibility is not guaranteed.
 

--- a/streamlit-python/src/module-ui/src/environment.yml
+++ b/streamlit-python/src/module-ui/src/environment.yml
@@ -4,4 +4,4 @@
 channels:
 - snowflake
 dependencies:
-- streamlit=1.22.0
+- streamlit=1.26.0


### PR DESCRIPTION
- Bump Streamlit version to 1.26.
- Update .gitignore
- Ensure version of snowCLI in conda is 2+.

Fixes #10 

Tested using Snow CLI, and confirmed st.__version__ in use in Snowflake changed from 1.22 to 1.26.