### PR TITLE
Redo templates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Please refer to the [Snowflake CLI Documentation](https://docs.snowflake.com/en/
 
 ### Note
 You can also clone this repository manually using `git` and simply modify the template you would like to use.
-Note that any jinja files in this repository will not be rendered to their intended file type if using this option. 
+Note that any files in this repository containing Jinja template tags will not be rendered to their intended file type if using this option. 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,33 @@
 # Snowflake Native App Templates with Snowflake CLI
 **Note**: Snowflake CLI is in Public Preview (PuPr). You can find the official documentation [here](https://docs.snowflake.com/en/developer-guide/snowflake-cli-v2/index).
 
-This repository contains [Snowflake Native App](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about) templates released by Snowflake Inc. These templates are customized to work with Snowflake CLI. 
+This repository contains [Snowflake Native App](https://docs.snowflake.com/en/developer-guide/native-apps/native-apps-about) templates released by Snowflake Inc. and are designed to work with Snowflake CLI.
 
 ## Available Templates
-There are three available templates in the current version of this repository:
-1. [basic](./basic/README.md)
-2. [spcs-basic](./spcs-basic/README.md)
-3. [streamlit-python](./streamlit-python/README.md)
-4. [streamlit-java](./streamlit-java/README.md)
+The current list of templates is as follows:
 
-For a detailed understanding of the templates, please refer to the README.md within each template. 
+1. [basic](./basic/README.md) (default)
+2. [spcs-basic](./spcs-basic/README.md)
+3. [streamlit-java](./streamlit-java/README.md)
+4. [streamlit-javascript](./streamlit-javascript/README.md)
+5. [streamlit-python](./streamlit-python/README.md)
+
+See the `README.md` file in the root of each template directory for more information.
 
 ### Note
-These templates are not an exhaustive list of use cases or possibilities that developers may want to explore when building their Snowflake Native App. 
-
+These templates are not an exhaustive list of use cases or possibilities for building Snowflake Native Apps;
+take a look at the [native-apps-examples](https://github.com/snowflakedb/native-apps-examples) repository for more fully-featured examples.
 
 ## How to Use the Templates
 
-There are two ways you can use the templates provided in this repository. 
+Snowflake CLI contains built-in functionality to initialize project directories on your local filesystem using the templates in this (or any other) repository. For example, to initialize a new Snowflake Native App project called `my-app` using the `spcs-basic` template, run the following command:
 
-1. Using Snowflake CLI (recommended)
+```bash
+snow app init my-app --template spcs-basic
+```
 
-    For more information, please refer to the [Snowflake CLI Documentation](https://docs.snowflake.com/en/developer-guide/snowflake-cli-v2/index) on installing and using Snowflake CLI to create a Snowflake Native App. 
-    
-    Once Snowflake CLI is installed and configured, run the following command in your terminal.
-    ```
-    snow app init <project_name> [--template={basic|streamlit-python|streamlit-java}]
-    ```
-    The command above is equivalent to the one below since `--template-repo` is optional if you intend to use any templates provided in this repository.  
-    ```
-    snow app init <project_name> [--template-repo=https://github.com/snowflakedb/native-apps-templates.git] [--template={basic|streamlit-python|streamlit-java}]
-    ```
+Please refer to the [Snowflake CLI Documentation](https://docs.snowflake.com/en/developer-guide/snowflake-cli-v2/index) for more information on installing and using Snowflake CLI.
 
-2. Using git clone
-
-    You can also clone this repository manually and keep the template you would like to use. But as a note, any jinja files in this repository will not be rendered to their intended file type if using this option. 
+### Note
+You can also clone this repository manually using `git` and simply modify the template you would like to use.
+Note that any jinja files in this repository will not be rendered to their intended file type if using this option. 


### PR DESCRIPTION
The existing README didn't have the right templates listed. I took the opportunity to simplify the copy while maintaining the Snowflake brand guidelines, as well as adding a link to the examples repository.